### PR TITLE
Allow number in filename

### DIFF
--- a/ci/.github/lint-filename.sh
+++ b/ci/.github/lint-filename.sh
@@ -9,13 +9,13 @@
 set -e
 
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-GO_REGEX="^[a-zA-Z_]+\.go$"
+GO_REGEX="^[a-zA-Z0-9_]+\.go$"
 
 find  "$SCRIPT_PATH/.." -name "*.go" | while read fullpath; do
   filename=$(basename -- "$fullpath")
 
   if ! [[ $filename =~ $GO_REGEX ]]; then
-      echo "$filename is not a valid filename for Go code, only alpha and underscores are supported"
+      echo "$filename is not a valid filename for Go code, only alpha, numbers and underscores are supported"
       exit 1
   fi
 done


### PR DESCRIPTION
The official package encoding/base64 uses numbers in the filename.

Fix #7