### PR TITLE
lint(filename): Tighten up the regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Sean DuBois](https://github.com/Sean-Der) - *Original Author of the lint scripts*
 * [Max Hawkins](https://github.com/maxhawkins) - *Git hooks*
 * [Atsushi Watanabe](https://github.com/at-wat) - *Sync files among repositories*
+* [Daniele Sluijters](https://github.com/daenney) - *Misc fixes*
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/ci/.github/lint-filename.sh
+++ b/ci/.github/lint-filename.sh
@@ -9,7 +9,7 @@
 set -e
 
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
-GO_REGEX="^[a-zA-Z0-9_]+\.go$"
+GO_REGEX="^[a-zA-Z][a-zA-Z0-9_]*\.go$"
 
 find  "$SCRIPT_PATH/.." -name "*.go" | while read fullpath; do
   filename=$(basename -- "$fullpath")


### PR DESCRIPTION
Follow-up from: https://github.com/pion/dtls/pull/176#discussion_r366268233

All files must start with a letter. Though this is not mandated by
the Go toolchain, it looks weird having .go files starting with a
number and it's extremely rare in the wild. Additionally the old
regex allowed for filenames to start with an underscore which is
also a bit peculiar.

As long as a file now starts with a letter, it can be followed up by any
combination of letters, numbers and underscores. We could write an even
more pedantic linter, but this is probably good enough.