### PR TITLE
Ignore new-line in commit msg subject length check

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Max Hawkins](https://github.com/maxhawkins) - *Git hooks*
 * [Atsushi Watanabe](https://github.com/at-wat) - *Sync files among repositories*
 * [Daniele Sluijters](https://github.com/daenney) - *Misc fixes*
+* [Luke S](https://github.com/encounter)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/ci/.github/lint-commit-message.sh
+++ b/ci/.github/lint-commit-message.sh
@@ -31,7 +31,7 @@ lint_commit_message() {
         display_commit_message_error "$1" 'Separate subject from body with a blank line'
     fi
 
-    if [[ "$(echo "$1" | head -n1 | wc -m)" -gt 50 ]]; then
+    if [[ "$(echo "$1" | head -n1 | awk '{print length}')" -gt 50 ]]; then
         display_commit_message_error "$1" 'Limit the subject line to 50 characters'
     fi
 


### PR DESCRIPTION
Using a carefully crafted 50 character subject line,
we can test that this lint doesn't include the newline
in its calculation.
