### PR TITLE
Report patch coverage status only on pulls

### DIFF
--- a/ci/codecov.yml
+++ b/ci/codecov.yml
@@ -13,6 +13,7 @@ coverage:
     patch:
       default:
         target: 70%
+        only_pulls: true
 
 ignore:
   - "examples/*"


### PR DESCRIPTION
We sometimes merge PRs with low patch coverage for some reasons.
Once they have been merged, it's no longer needed to make commit
status error.
