### PR TITLE
Removing ion from sync

### DIFF
--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -16,7 +16,6 @@ jobs:
             pion/datachannel
             pion/dtls
             pion/ice
-            pion/ion
             pion/logging
             pion/mdns
             pion/quic

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Daniele Sluijters](https://github.com/daenney) - *Misc fixes*
 * [Luke S](https://github.com/encounter)
 * [Aurken Bilbao](https://github.com/aurkenb) - *Misc fixes*
+* [Tarrence van As](https://github.com/tarrencev)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text


### PR DESCRIPTION
Ion requires a more tailored CI integration. I'm going to modify the current PR created by Pion bot for our use case.