### PR TITLE
Add GOLANGCI_LINT_EXRA_ARGS

### DIFF
--- a/ci/.travis.yml
+++ b/ci/.travis.yml
@@ -43,7 +43,7 @@ _lint_job: &lint_job
     - bash .github/lint-disallowed-functions-in-library.sh
     - bash .github/lint-commit-message.sh
     - bash .github/lint-filename.sh
-    - golangci-lint run ./...
+    - golangci-lint run ${GOLANGCI_LINT_EXRA_ARGS:-} ./...
 _test_job: &test_job
   env: CACHE_NAME=test
   before_install:


### PR DESCRIPTION
To specify arguments like --build-tags to golanci-lint.

### Reference issue
For https://github.com/pion/webrtc/pull/1294#discussion_r454691021