### PR TITLE
Add 'github.com/pkg/errors' to blocked modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Check out the **[contributing wiki](https://github.com/pion/webrtc/wiki/Contribu
 * [Aurken Bilbao](https://github.com/aurkenb) - *Misc fixes*
 * [Tarrence van As](https://github.com/tarrencev)
 * [Michiel De Backker](https://github.com/backkem) - *Add pion/udp*
+* [ZHENK](https://github.com/scorpionknifes)
 
 ### License
 MIT License - see [LICENSE](LICENSE) for full text

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -5,6 +5,12 @@ linters-settings:
     locale: US
   exhaustive:
     default-signifies-exhaustive: true
+  gomodguard:
+    blocked:
+      modules:
+        - github.com/pkg/errors:
+            recommendations:
+            - errors
 
 linters:
   enable:


### PR DESCRIPTION
#### Description

Added `github.com/pkg/errors` to blocked modules in `.golangci.yml`

Example lint warning
```
import of package `github.com/pkg/errors` is blocked because the module is in the blocked modules list. `errors` is a recommended module. (gomodguard)
```

Tested on [pion/sctp](https://github.com/pion/sctp)

#### Reference issue
Fixes #48 
https://github.com/pion/sctp/pull/154

