### PR TITLE
Fix lint-commit-message for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,10 @@
-name: lint
+name: Lint
 on:
-  push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
+    types:
+      - opened
+      - edited
+      - synchronize
 jobs:
   commit-lint:
     runs-on: ubuntu-latest
@@ -13,25 +12,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 50
+          fetch-depth: 0
       - name: copy scripts
         run: cp ci/.github/*.sh .github/
       - name: assert contributors
         run: .github/assert-contributors.sh
       - name: lint commit message
-        run: |
-          git fetch --no-tags --prune --depth=1 origin +refs/heads/*:refs/remotes/origin/*
-          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
-            echo "This is a pull request build"
-            base_sha=$(git show --pretty=raw | grep '^parent' | cut -f2 -d' ' | sed -n '1p')
-            head_sha=$(git show --pretty=raw | grep '^parent' | cut -f2 -d' ' | sed -n '2p')
-            export TRAVIS_COMMIT_RANGE=${base_sha}...${head_sha}
-          else
-            echo "This is a branch build"
-            git fetch --depth=50 origin ${{ github.ref }}
-            export TRAVIS_COMMIT_RANGE=$(git log --format="%H" | tail -n1)...${{ github.ref }}
-          fi
-          echo "Emulated TRAVIS_COMMIT_RANGE: ${TRAVIS_COMMIT_RANGE}"
-          git log --oneline --graph ${TRAVIS_COMMIT_RANGE}
-          echo "Linting commit message"
-          .github/lint-commit-message.sh
+        run: .github/lint-commit-message.sh

--- a/ci/.github/assert-contributors.sh
+++ b/ci/.github/assert-contributors.sh
@@ -11,12 +11,6 @@
 
 set -e
 
-# Unshallow the repo, this check doesn't work with this enabled
-# https://github.com/travis-ci/travis-ci/issues/3412
-if [ -f $(git rev-parse --git-dir)/shallow ]; then
-	git fetch --unshallow || true
-fi
-
 SCRIPT_PATH=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 
 if [ -f ${SCRIPT_PATH}/.ci.conf ]

--- a/ci/.github/lint-commit-message.sh
+++ b/ci/.github/lint-commit-message.sh
@@ -58,13 +58,7 @@ if [ "$#" -eq 1 ]; then
    fi
    lint_commit_message "$(sed -n '/# Please enter the commit message for your changes. Lines starting/q;p' "$1")"
 else
-    # TRAVIS_COMMIT_RANGE is empty for initial branch commit
-    if [[ "${TRAVIS_COMMIT_RANGE}" != *"..."* ]]; then
-        parent=$(git log -n 1 --format="%P" ${TRAVIS_COMMIT_RANGE})
-        TRAVIS_COMMIT_RANGE="${TRAVIS_COMMIT_RANGE}...$parent"
-    fi
-
-    for commit in $(git rev-list ${TRAVIS_COMMIT_RANGE}); do
+    for commit in $(git rev-list --no-merges origin/master..); do
       lint_commit_message "$(git log --format="%B" -n 1 $commit)"
     done
 fi

--- a/ci/.github/workflows/lint.yaml
+++ b/ci/.github/workflows/lint.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
         - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
 
         - name: Commit Message
           run: .github/lint-commit-message.sh


### PR DESCRIPTION
Before this script was only checking HEAD, now it checks every commit
in the PR.