### PR TITLE
Fix lint-disallowed-functions-in-library

### DIFF
--- a/ci/.github/lint-disallowed-functions-in-library.sh
+++ b/ci/.github/lint-disallowed-functions-in-library.sh
@@ -41,7 +41,7 @@ files=$(
 
 for disallowedFunction in "${DISALLOWED_FUNCTIONS[@]}"
 do
-	if grep -e "$disallowedFunction" $files | grep -v -e 'nolint'; then
+	if grep -e "\s$disallowedFunction" $files | grep -v -e 'nolint'; then
 		echo "$disallowedFunction may only be used in example code"
 		exit 1
 	fi


### PR DESCRIPTION
When grepping for `print(` we would incorrectly catch functions like
`checkFingerprint(`. This commits require one whitespace character so
we don't get false positives anymore.
