### PR TITLE
Generate the authors file only for pion members

### DIFF
--- a/ci/.github/workflows/generate-authors.yml
+++ b/ci/.github/workflows/generate-authors.yml
@@ -5,6 +5,9 @@ on:
 
 jobs:
   generate-authors:
+    env:
+      PIONBOT_PRIVATE_KEY: ${{ secrets.PIONBOT_PRIVATE_KEY }}
+    if: env.PIONBOT_PRIVATE_KEY != null
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Add an if to the generate-authors job so it only runs if it has secret
access