### PR TITLE
Avoid passing token to third-party actions

### DIFF
--- a/ci/.github/workflows/generate-authors.yml
+++ b/ci/.github/workflows/generate-authors.yml
@@ -52,11 +52,11 @@ jobs:
       run: |
         echo "::set-output name=msg::$(git status -s | wc -l)"
 
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - name: Commit and push
       if: ${{ steps.git-status-output.outputs.msg != '0' }}
-      with:
-        commit_message: ${{ steps.last-commit-message.outputs.msg }}
-        commit_author: ${{ steps.last-commit-author.outputs.msg }}
-        commit_options: '--amend --no-edit'
-        push_options: '--force'
-        skip_fetch: true
+      run: |
+        git config user.email $(echo "${{ steps.last-commit-author.outputs.msg }}" | sed 's/\(.\+\) <\(\S\+\)>/\2/')
+        git config user.name $(echo "${{ steps.last-commit-author.outputs.msg }}" | sed 's/\(.\+\) <\(\S\+\)>/\1/')
+        git add AUTHORS.txt
+        git commit --amend --no-edit
+        git push --force https://github.com/${GITHUB_REPOSITORY} $(git symbolic-ref -q --short HEAD)


### PR DESCRIPTION
To minimize future security risk like codecov incident.
