### PR TITLE
Post request to update AUTHORS.txt on forked repo

### DIFF
--- a/ci/.github/workflows/generate-authors.yml
+++ b/ci/.github/workflows/generate-authors.yml
@@ -29,20 +29,25 @@ jobs:
 
   generate-authors:
     needs: [checksecret]
-    if: needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set == 'true'
     runs-on: ubuntu-latest
+    if: github.actor != 'pionbot'
     steps:
     - uses: actions/checkout@v2
+      if: needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set == 'true'
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0
         token: ${{ secrets.PIONBOT_PRIVATE_KEY }}
+    - uses: actions/checkout@v2
+      if: needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set != 'true'
+      with:
+        repository: ${{ github.pull_request.head.repo.full_name }}
+        ref: ${{ github.pull_request.head.ref }}
+        fetch-depth: 0
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Generate the authors file
       run: .github/generate-authors.sh
-
-    - name: Add the authors file to git
-      run: git add AUTHORS.txt
 
     - name: Get last commit message
       id: last-commit-message
@@ -64,10 +69,17 @@ jobs:
         echo "::set-output name=msg::$(git status -s | wc -l)"
 
     - name: Commit and push
-      if: ${{ steps.git-status-output.outputs.msg != '0' }}
+      if: steps.git-status-output.outputs.msg != '0' && needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set == 'true'
       run: |
         git config user.email $(echo "${{ steps.last-commit-author.outputs.msg }}" | sed 's/\(.\+\) <\(\S\+\)>/\2/')
         git config user.name $(echo "${{ steps.last-commit-author.outputs.msg }}" | sed 's/\(.\+\) <\(\S\+\)>/\1/')
         git add AUTHORS.txt
         git commit --amend --no-edit
         git push --force https://github.com/${GITHUB_REPOSITORY} $(git symbolic-ref -q --short HEAD)
+
+    - name: Add annotation about updating AUTHORS.txt
+      if: steps.git-status-output.outputs.msg != '0' && needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set != 'true'
+      run: |
+        line=$(git diff | sed -n '/^@@/s/@@ -\([0-9]\)\+,.*/\1/p' | head -n1)
+        patch="$(git diff | sed -s 's/%/%25/g;s/$/%0A/g;' | tr -d '\n')"
+        echo "::error file=AUTHORS.txt,line=${line},col=0::Thank you for your contribution @${{ github.actor }}!%0ADo you mind updating AUTHORS.txt as following?%0A%0A${patch}%0A"


### PR DESCRIPTION
In the current contributor list rule, reviewers should ask first time contributors opening PR from forked repository to manually update AUTHORS.txt.
It's complicated for the first time contributors and also the reviewers. e.g. https://github.com/pion/srtp/pull/146

This PR adds partial support for forked PRs to generate-authors workflow.
If AUTHORS.txt is not updated and the PR is from a forked repo, CI will fail and a patch to update AUTHORS.txt will be posted as a check annotation. 
example: https://github.com/pion/ci-sandbox/pull/13/files#diff-b897336dda0579c40f3623b68eb6652ded79e206f4cf1af7ceb24b683fd46ff1
![image](https://user-images.githubusercontent.com/8390204/126601424-4ce88613-1bfd-4d56-9730-98ba85c1daba.png)
