### PR TITLE
Use gotestfmt for better output in Actions

### DIFF
--- a/ci/.github/workflows/test.yaml
+++ b/ci/.github/workflows/test.yaml
@@ -43,19 +43,30 @@ jobs:
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Setup go-acc
-        run: |
-          go get github.com/ory/go-acc
-          git checkout go.mod go.sum
+      - name: Set up gotestfmt
+        uses: haveyoudebuggedit/gotestfmt-action@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }} # Avoid getting rate limited
 
       - name: Run test
         run: |
           TEST_BENCH_OPTION="-bench=."
           if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
 
-          go-acc -o cover.out ./... -- \
+          set -euo pipefail
+          go test -coverprofile=cover.out -covermode=atomic \
             ${TEST_BENCH_OPTION} \
-            -v -race
+            -json \
+            -v -race \
+            ./... 2>&1 | tee /tmp/gotest.log | gotestfmt
+
+      - name: Upload test log
+        uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: test-log
+          path: /tmp/gotest.log
+          if-no-files-found: error
 
       - name: Run TEST_HOOK
         run: |


### PR DESCRIPTION
gotestfmt results in much more readable output in GitHub Actions than just running go test.
