### PR TITLE
Interpolate the Go version in the test log name

### DIFF
--- a/ci/.github/workflows/test.yaml
+++ b/ci/.github/workflows/test.yaml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: test-log
+          name: test-log-${{ matrix.go }}
           path: /tmp/gotest.log
           if-no-files-found: error
 


### PR DESCRIPTION
Artifacts are "global" to the run, not scoped to the matrix. Without interpolating something like the Go version, we only end up with one log file, the last one to get uploaded.
