### PR TITLE
Enable CodeQL scanning for PRs

### DIFF
--- a/ci/.github/workflows/codeql-analysis.yml
+++ b/ci/.github/workflows/codeql-analysis.yml
@@ -4,6 +4,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '23 5 * * 0'
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '**.go'
 
 jobs:
   analyze:


### PR DESCRIPTION
With pion/webrtc#2208 and pion/sdp#131 resolved we don't have any open
CodeQL alerts anymore. As such, enable CodeQL scanning on PRs now so
that we don't introduce new issues.