### PR TITLE
Slow down the assets sync

### DIFF
--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -30,6 +30,7 @@ jobs:
             pion/udp
             pion/webrtc
           root_dir: ci
+          push_interval: 10
           git_user: Pion Bot
           git_email: 59523206+pionbot@users.noreply.github.com
           github_token: ${{ secrets.PIONBOT_ASSETS_SYNC_TOKEN }}


### PR DESCRIPTION
With the number of repos we sync, we hit GitHub's API rate limit if we
do too many in a row. So, sleep for 10s between each. This'll slow down
the assets sync a bit, but should result in it now completing reliably
every time.
