### PR TITLE
Set permissions on Actions workflows

### DIFF
--- a/ci/.github/workflows/generate-authors.yml
+++ b/ci/.github/workflows/generate-authors.yml
@@ -16,6 +16,8 @@ on:
 
 jobs:
   checksecret:
+    permissions:
+      contents: none
     runs-on: ubuntu-latest
     outputs:
       is_PIONBOT_PRIVATE_KEY_set: ${{ steps.checksecret_job.outputs.is_PIONBOT_PRIVATE_KEY_set }}
@@ -28,6 +30,8 @@ jobs:
           echo "::set-output name=is_PIONBOT_PRIVATE_KEY_set::${{ env.PIONBOT_PRIVATE_KEY != '' }}"
 
   generate-authors:
+    permissions:
+      contents: write
     needs: [checksecret]
     if: needs.checksecret.outputs.is_PIONBOT_PRIVATE_KEY_set == 'true'
     runs-on: ubuntu-latest

--- a/ci/.github/workflows/lint.yaml
+++ b/ci/.github/workflows/lint.yaml
@@ -16,6 +16,10 @@ on:
       - opened
       - edited
       - synchronize
+
+permissions:
+  contents: read
+
 jobs:
   lint-commit-message:
     name: Metadata
@@ -41,6 +45,9 @@ jobs:
 
   lint-go:
     name: Go
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/ci/.github/workflows/renovate-go-mod-fix.yaml
+++ b/ci/.github/workflows/renovate-go-mod-fix.yaml
@@ -15,6 +15,9 @@ on:
     branches:
       - renovate/*
 
+permissions:
+  contents: write
+
 jobs:
   go-mod-fix:
     runs-on: ubuntu-latest

--- a/ci/.github/workflows/test.yaml
+++ b/ci/.github/workflows/test.yaml
@@ -17,6 +17,10 @@ on:
   pull_request:
     branches:
     - master
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/ci/.github/workflows/tidy-check.yaml
+++ b/ci/.github/workflows/tidy-check.yaml
@@ -18,6 +18,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   Check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicitly configure the required permissions for the access token on
the workflows. This lets us change the org default from read/write for
the token to just read.