### PR TITLE
Start testing with Go 1.18

### DIFF
--- a/ci/.github/workflows/test.yaml
+++ b/ci/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.16", "1.17"]
+        go: ["1.17", "1.18"]
       fail-fast: false
     name: Go ${{ matrix.go }}
     steps:


### PR DESCRIPTION
Now that 1.18 has been out for a couple of months, drop 1.16 from
testing and add 1.18 as we normally support the latest 2 Go versions.