### PR TITLE
Add release automation using goreleaser

### DIFF
--- a/ci/.github/workflows/release.yml
+++ b/ci/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: release
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    permissions:
+        contents: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-go@v3
+      with:
+        go-version: '1.18' # auto-update/latest-go-version
+    - name: Build and release
+      uses: goreleaser/goreleaser-action@v3
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ci/.goreleaser.yml
+++ b/ci/.goreleaser.yml
@@ -1,0 +1,2 @@
+builds:
+- skip: true


### PR DESCRIPTION
This configures goreleaser in "library" mode, i.e it doesn't build any
CLIs, Docker images etc. It only creates a release based on the Git tag
that was pushed with a Changelog enumerating the commits.

Though the changelog isn't super useful without some commit message
standardisation, it's already a lot better than not having one at all.
Now folks can look at the release on GitHub to see what's changed
instead of having to browse the history on GItHub or clone and run git
log.