### PR TITLE
Set Go version using workflow options

### DIFF
--- a/.github/workflows/update-go-version.yml
+++ b/.github/workflows/update-go-version.yml
@@ -23,7 +23,7 @@ jobs:
           go_version_prev=${go_major}.${go_minor_prev}
 
           workflows="$(find ./ci/.github/workflows -name "*.yaml" -o -name "*.yml")"
-          sed "s|\[.*\]\( # auto-update/supported-go-version-list\)|['${go_version}', '${go_version_prev}']\1|" -i ${workflows}
+          sed "s|['\"]\?[0-9.]*['\"]\?\( # auto-update/previous-go-version\)|'${go_version_prev}'\1|" -i ${workflows}
           sed "s|['\"]\?[0-9.]*['\"]\?\( # auto-update/latest-go-version\)|'${go_version}'\1|" -i ${workflows}
       - name: Commit changes
         run: |

--- a/ci/.github/workflows/release.yml
+++ b/ci/.github/workflows/release.yml
@@ -3,6 +3,13 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_call:
+    inputs:
+      go:
+        description: 'Go version'
+        default: 1.18 # auto-update/latest-go-version
+        required: false
+        type: string
 
 jobs:
   release:
@@ -15,7 +22,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18' # auto-update/latest-go-version
+        go-version: ${{ inputs.go }}
     - name: Build and release
       uses: goreleaser/goreleaser-action@v3
       with:

--- a/ci/.github/workflows/test.yaml
+++ b/ci/.github/workflows/test.yaml
@@ -17,6 +17,19 @@ on:
   pull_request:
     branches:
     - master
+  workflow_call:
+    inputs:
+      go_prev:
+        description: 'Go version -1'
+        default: 1.17 # auto-update/previous-go-version
+        required: false
+        type: string
+      go:
+        description: 'Go version'
+        default: 1.18 # auto-update/latest-go-version
+        required: false
+        type: string
+
 
 permissions:
   contents: read
@@ -26,7 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17", "1.18"] # auto-update/supported-go-version-list
+        go:
+          - ${{ inputs.go_prev }}
+          - ${{ inputs.go }}
       fail-fast: false
     name: Go ${{ matrix.go }}
     steps:
@@ -89,7 +104,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.17", "1.18"] # auto-update/supported-go-version-list
+        go:
+          - ${{ inputs.go_prev }}
+          - ${{ inputs.go }}
       fail-fast: false
     name: Go i386 ${{ matrix.go }}
     steps:
@@ -145,7 +162,7 @@ jobs:
       - name: Download Go
         run: curl -sSfL https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz | tar -C ~ -xzf -
         env:
-          GO_VERSION: 1.17 # auto-update/latest-go-version
+          GO_VERSION: ${{ inputs.go }}
 
       - name: Set Go Root
         run: echo "GOROOT=${HOME}/go" >> $GITHUB_ENV


### PR DESCRIPTION
This adds a bit of flexibility to the workflows in that you can now chose which version(s) of Go you want to run a workflow with.

Since `workflow_call` `inputs` can't be an array we introduce the `go_prev` input and instead of having `supported-go-version-list` we now have `previous-go-version`. This lets us use both in the `matrix` config.