### PR TITLE
Do not run generate-authors on Renovate PRs

### DIFF
--- a/ci/.github/workflows/generate-authors.yml
+++ b/ci/.github/workflows/generate-authors.yml
@@ -13,6 +13,8 @@ name: generate-authors
 
 on:
   pull_request:
+    branches-ignore:
+      - 'renovate/*'
 
 jobs:
   checksecret:


### PR DESCRIPTION
Avoid endless force push loop.