### PR TITLE
release: Fix deprecation warning

### DIFF
--- a/.github/workflows/release.reusable.yml
+++ b/.github/workflows/release.reusable.yml
@@ -23,6 +23,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`--rm-dist` is now deprecated in favour of `--clean`. This commit switches our usage.