### PR TITLE
Fix module update commit regex

### DIFF
--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -34,7 +34,7 @@ lint_commit_message() {
   fi
 
   if [[ "$(echo "$1" | head -n1 | awk '{print length}')" -gt 50 ]]; then
-    re='^Update module github.com/[0-9a-zA-Z./]+ to v[0-9]+\.[0-9]+\.[0-9]+$'
+    re='^Update module [0-9a-zA-Z./]+ to v[0-9]+\.[0-9]+\.[0-9]+( \[.*\])?$'
     if [[ "$(echo "$1" | head -n1)" =~ $re ]]; then
       echo "Ignored subject line length error for module update commit"
     else


### PR DESCRIPTION
Allow commits like `Update module golang.org/x/net to v0.7.0 [SECURITY]`

tested at: https://github.com/pion/.goassets/pull/145 https://github.com/pion/.goassets/pull/146

---
Close https://github.com/pion/.goassets/pull/145
Close https://github.com/pion/.goassets/pull/146
