### PR TITLE
Add support for {PRE,POST}_TEST_HOOKs

### DIFF
--- a/.github/workflows/test-wasm.reusable.yml
+++ b/.github/workflows/test-wasm.reusable.yml
@@ -52,8 +52,10 @@ jobs:
       - name: Run Tests
         run: |
           if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
-          GOOS=js GOARCH=wasm $GOPATH/bin/go test \
-            -coverprofile=cover.out -covermode=atomic \
+          GOOS=js GOARCH=wasm \
+          ${GOPATH}/bin/go test \
+            -coverprofile=cover.out \
+            -covermode=atomic \
             -exec="${GO_JS_WASM_EXEC}" \
             -v ./...
 

--- a/.github/workflows/test.reusable.yml
+++ b/.github/workflows/test.reusable.yml
@@ -41,16 +41,26 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }} # Avoid getting rate limited
 
+      - name: Run pre test hook
+        run: |
+          if [ -f .github/.ci.conf ]; && . .github/.ci.conf
+          [ -n "${PRE_TEST_HOOK}" ] && ${PRE_TEST_HOOK}
+
       - name: Run test
         run: |
           TEST_BENCH_OPTION="-bench=."
-          if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
+          [ -f .github/.ci.conf ] && . .github/.ci.conf
 
           set -euo pipefail
           go-acc -o cover.out ./... -- \
             ${TEST_BENCH_OPTION} \
             -json \
             -v -race 2>&1 | grep -v '^go: downloading' | tee /tmp/gotest.log | gotestfmt
+
+      - name: Run post test hook
+        run: |
+          [ -f .github/.ci.conf ] && . .github/.ci.conf
+          [ -n "${POST_TEST_HOOK}" ] && ${POST_TEST_HOOK}
 
       - name: Upload test log
         uses: actions/upload-artifact@v3
@@ -59,11 +69,6 @@ jobs:
           name: test-log-${{ inputs.go-version }}
           path: /tmp/gotest.log
           if-no-files-found: error
-
-      - name: Run TEST_HOOK
-        run: |
-          if [ -f .github/.ci.conf ]; then . .github/.ci.conf; fi
-          if [ -n "${TEST_HOOK}" ]; then ${TEST_HOOK}; fi
 
       - uses: codecov/codecov-action@v3
         with:


### PR DESCRIPTION
I need a pre-test hook to install some required dependencies for the tests of `pion/portmap`:

https://github.com/pion/portmap/blob/master/.github/.ci.conf

Currently only `pion/stun` is using the old `TEST_HOOK` variable which I will fix this during the asset sync.