### PR TITLE
Check Go version in go.mod

### DIFF
--- a/.github/workflows/lint.reusable.yml
+++ b/.github/workflows/lint.reusable.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Logging messages should not have trailing newlines
         run: .github/.goassets/scripts/lint-no-trailing-newline-in-log-messages.sh
 
+      - name: Go version in go.mod
+        run: .github/.goassets/scripts/lint-go-mod-version.sh
+
   lint-go:
     name: Go
     permissions:

--- a/.github/workflows/update-go-version.yml
+++ b/.github/workflows/update-go-version.yml
@@ -25,9 +25,12 @@ jobs:
           go_minor_prev=$((${go_minor} - 1))
           go_version_prev=${go_major}.${go_minor_prev}
 
+          scripts="$(find ./scipts -name "*.sh")"
           workflows="$(find ./ci/.github/workflows -name "*.yaml" -o -name "*.yml")"
-          sed "s|\[.*\]\( # auto-update/supported-go-version-list\)|['${go_version}', '${go_version_prev}']\1|" -i ${workflows}
-          sed "s|['\"]\?[0-9.]*['\"]\?\( # auto-update/latest-go-version\)|'${go_version}'\1|" -i ${workflows}
+
+          sed "s|\[.*\]\( # auto-update/supported-go-version-list\)|[\"${go_version}\", \"${go_version_prev}\"]\1|" -i ${workflows}
+          sed "s|['\"]\?[0-9.]*['\"]\?\( # auto-update/latest-go-version\)|\"${go_version}\"\1|" -i ${workflows} ${scripts}
+          sed "s|['\"]\?[0-9.]*['\"]\?\( # auto-update/prev-go-version\)|\"${go_version_prev}\"\1|" -i ${workflows} ${scripts}
       - name: Commit changes
         run: |
           git config --global user.name "Pion Bot"

--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -5,7 +5,7 @@
 set -e
 
 display_commit_message_error() {
-  if [ -n "${CI}" ]; then
+  if [[ -n "${CI}" ]]; then
     echo "::error title=Commit message check failed::$2"
     echo -e "::group::Commit message\n$1\n::endgroup::"
   else

--- a/scripts/lint-go-mod-version.sh
+++ b/scripts/lint-go-mod-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2023 The Pion community <https://pion.ly>
+# SPDX-License-Identifier: MIT
+
+set -e
+
+SCRIPT_PATH=$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  pwd -P
+)
+
+if [ -f ${SCRIPT_PATH}/.ci.conf ]; then
+  . ${SCRIPT_PATH}/.ci.conf
+fi
+
+if [ -z "${GO_MOD_VERSION_EXPECTED}" ]; then
+  GO_MOD_VERSION_EXPECTED="1.19" # auto-update/prev-go-version
+fi
+
+GO_MOD_FILE=go.mod
+GO_MOD_VERSION=$(sed -En 's/^go[[:space:]]+([[:digit:].]+)$/\1/p' ${GO_MOD_FILE})
+
+if [[ ${GO_MOD_VERSION} != ${GO_MOD_VERSION_EXPECTED} ]]; then
+  if [[ -n "${CI}" ]]; then
+    GO_MOD_VERSION_LINE=$(sed -n '/^go/=' go.mod)
+    echo "::error title=Invalid Go version,file=${GO_MOD_FILE},line=${GO_MOD_VERSION_LINE},::Found ${GO_MOD_VERSION}. Expected ${GO_MOD_VERSION_EXPECTED}"
+  else
+    echo "Invalid Go version in go.mod:"
+    echo "  Found    ${GO_MOD_VERSION}"
+    echo "  Expected ${GO_MOD_VERSION_EXPECTED}"
+  fi
+fi

--- a/scripts/lint-no-trailing-newline-in-log-messages.sh
+++ b/scripts/lint-no-trailing-newline-in-log-messages.sh
@@ -4,7 +4,6 @@
 
 set -e
 
-# Disallow usages of functions that cause the program to exit in the library code
 SCRIPT_PATH=$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   pwd -P


### PR DESCRIPTION
We currently have a mixture of different versions in `go.mod`. This linter check should harmonize it.