### PR TITLE
Fix commit message lint for non-master branches

### DIFF
--- a/scripts/lint-commit-message.sh
+++ b/scripts/lint-commit-message.sh
@@ -66,7 +66,7 @@ if [ "$#" -eq 1 ]; then
   fi
   lint_commit_message "$(sed -n '/# Please enter the commit message for your changes. Lines starting/q;p' "$1")"
 else
-  for COMMIT in $(git rev-list --no-merges origin/master..); do
+  for COMMIT in $(git rev-list --no-merges origin/${GITHUB_BASE_REF:-master}..); do
     lint_commit_message "$(git log --format="%B" -n 1 ${COMMIT})"
   done
 fi


### PR DESCRIPTION
Fix checked commit range when PR base branch is not master.

### Reference issue
Fixes #198 
