### PR TITLE
Update Node to v20

### DIFF
--- a/.github/workflows/test-wasm.reusable.yml
+++ b/.github/workflows/test-wasm.reusable.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
 
       - uses: actions/cache@v4
         with:


### PR DESCRIPTION
Fix `TypeError: crypto.getRandomValues is not a function`

Also, Node v16 is EOL-ed