### PR TITLE
Fix node version for test with Go 1.20

### DIFF
--- a/.github/workflows/test-wasm.reusable.yml
+++ b/.github/workflows/test-wasm.reusable.yml
@@ -19,11 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20.x'
-
       - uses: actions/cache@v4
         with:
           path: |
@@ -41,6 +36,20 @@ jobs:
               | tail -n 1
           )
           curl -sSfL https://dl.google.com/go/${version}.linux-amd64.tar.gz | tar -C ~ -xzf -
+
+      - name: Node version
+        id: node-version
+        run: |
+          if [ '${{ inputs.go-version }}' = '1.20' ]; then
+            # Go 1.20's wasm_exec_node.js doesn't work with Node v20
+            # This can be removed once all pion repositories are switched to use Go 1.22
+            echo 'version=16' | tee -a ${GITHUB_OUTPUT}
+          fi
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '${{ steps.node-version.outputs.version || 20 }}.x'
 
       - name: Set Go Root
         run: echo "GOROOT=${HOME}/go" >> $GITHUB_ENV


### PR DESCRIPTION
Go 1.20's wasm_exec_node.js isn't compatible with Node v20