### PR TITLE
Fix deprecated golangci-lint config

### DIFF
--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -3,7 +3,8 @@
 
 linters-settings:
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   misspell:
     locale: US
   exhaustive:
@@ -110,6 +111,7 @@ linters:
 
 issues:
   exclude-use-default: false
+  exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
     - path: (examples|main\.go|_test\.go)
@@ -121,6 +123,3 @@ issues:
     - path: cmd
       linters:
         - forbidigo
-
-run:
-  skip-dirs-use-default: false


### PR DESCRIPTION
Executing `golangci-lint run` using old config generates the following warnings:

WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`.
WARN [config_reader] The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.

#### Description
Before
<img width="1123" alt="Screenshot 2024-04-01 at 20 59 13" src="https://github.com/pion/.goassets/assets/50456/e96a3112-c6f8-4965-906c-9e4f0d7b8136">

After
<img width="1124" alt="Screenshot 2024-04-01 at 21 26 42" src="https://github.com/pion/.goassets/assets/50456/36c3b427-fe2b-42b1-aeb5-328a6c285dd2">


#### Reference issue
No issue open