### PR TITLE
Fix error message and remove unreachable code

### DIFF
--- a/scripts/lint_no_trailing_newline_in_log_messages.go
+++ b/scripts/lint_no_trailing_newline_in_log_messages.go
@@ -37,8 +37,7 @@ func main() {
 
 		for _, match := range logReg.FindAll(fileContents, -1) {
 			if !strings.Contains(string(match), "nolint") {
-				return fmt.Errorf("Log format strings should have trailing new-line: %s", match)
-				os.Exit(1)
+				return fmt.Errorf("Log format strings should not have trailing new-line: %s", match)
 			}
 		}
 


### PR DESCRIPTION
Please correct me if I'm wrong, but I think the output should say "strings should *not* have trailing new-line".

The PR also removes an unreachable exit statement.