### PR TITLE
Impr/more linters

### DIFF
--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -16,7 +16,6 @@ jobs:
         uses: at-wat/assets-sync-action@v0
         with:
           repos: |
-            pion/bwe-test
             pion/datachannel
             pion/dtls
             pion/example-webrtc-applications

--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -16,6 +16,7 @@ jobs:
         uses: at-wat/assets-sync-action@v0
         with:
           repos: |
+            pion/bwe-test
             pion/datachannel
             pion/dtls
             pion/example-webrtc-applications

--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -24,7 +24,7 @@ jobs:
             pion/logging
             pion/mdns
             pion/opus
-            pion/peerconnection_explainer
+            pion/explainer
             pion/randutil
             pion/rtcp
             pion/rtp

--- a/.github/workflows/lint.reusable.yml
+++ b/.github/workflows/lint.reusable.yml
@@ -69,5 +69,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.62.2
           args: $GOLANGCI_LINT_EXRA_ARGS

--- a/.github/workflows/lint.reusable.yml
+++ b/.github/workflows/lint.reusable.yml
@@ -69,5 +69,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.62.2
+          version: v1.63.4
           args: $GOLANGCI_LINT_EXRA_ARGS

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -51,7 +51,6 @@ linters:
     - funlen           # Tool for detection of long functions
     - gci              # Gci control golang package import order and make it always deterministic.
     - gochecknoglobals # Checks that no globals are present in Go code
-    - gochecknoinits   # Checks that no init functions are present in Go code
     - gocognit         # Computes and checks the cognitive complexity of functions
     - goconst          # Finds repeated strings that could be replaced by a constant
     - gocritic         # The most opinionated Go source code linter
@@ -70,12 +69,10 @@ linters:
     - grouper          # An analyzer to analyze expression groups.
     - importas         # Enforces consistent import aliases
     - ineffassign      # Detects when assignments to existing variables are not used
-    - ireturn          # Accept Interfaces, Return Concrete Types
     - lll              # Reports long lines
     - maintidx         # maintidx measures the maintainability index of each function.
     - makezero         # Finds slice declarations with non-zero initial length
     - misspell         # Finds commonly misspelled English words in comments
-    - mnd              # An analyzer to detect magic numbers
     - nakedret         # Finds naked returns in functions greater than a specified function length
     - nestif           # Reports deeply nested if statements
     - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
@@ -98,10 +95,12 @@ linters:
     - varnamelen       # checks that the length of a variable's name matches its scope
     - wastedassign     # wastedassign finds wasted assignment statements
     - whitespace       # Tool for detection of leading and trailing whitespace
-    - wsl              # Whitespace Linter - Forces you to use empty lines!
   disable:
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages
+    - gochecknoinits   # Checks that no init functions are present in Go code
     - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - ireturn          # Accept Interfaces, Return Concrete Types
+    - mnd              # An analyzer to detect magic numbers
     - nolintlint       # Reports ill-formed or insufficient nolint directives
     - prealloc         # Finds slice declarations that could potentially be preallocated
     - promlinter       # Check Prometheus metrics naming via promlint
@@ -109,6 +108,7 @@ linters:
     - sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
     - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - wrapcheck        # Checks that errors returned from external packages are wrapped
+    - wsl              # Whitespace Linter - Forces you to use empty lines!
 
 issues:
   exclude-use-default: false

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -84,7 +84,6 @@ linters:
     - stylecheck       # Stylecheck is a replacement for golint
     - tagliatelle      # Checks the struct tags.
     - tenv             # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
-    - testpackage      # linter that makes you use a separate _test package
     - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert        # Remove unnecessary type conversions
@@ -106,6 +105,7 @@ linters:
     - promlinter       # Check Prometheus metrics naming via promlint
     - rowserrcheck     # checks whether Err of rows is checked successfully
     - sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
+    - testpackage      # linter that makes you use a separate _test package
     - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - wrapcheck        # Checks that errors returned from external packages are wrapped
     - wsl              # Whitespace Linter - Forces you to use empty lines!

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -25,6 +25,24 @@ linters-settings:
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+  varnamelen:
+    max-distance: 12
+    min-name-length: 2
+    ignore-type-assert-ok: true
+    ignore-map-index-ok: true
+    ignore-chan-recv-ok: true
+    ignore-decls:
+      - pc *PeerConnection
+      - pc *webrtc.PeerConnection
+      - wg *sync.WaitGroup
+      - wg sync.WaitGroup
+      - i int
+      - n int
+      - m map[string]interface{}
+      - w io.Writer
+      - r io.Reader
+      - b []byte
+
 
 linters:
   enable:

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -32,17 +32,11 @@ linters-settings:
     ignore-map-index-ok: true
     ignore-chan-recv-ok: true
     ignore-decls:
-      - pc *PeerConnection
-      - pc *webrtc.PeerConnection
-      - wg *sync.WaitGroup
-      - wg sync.WaitGroup
       - i int
       - n int
-      - m map[string]interface{}
       - w io.Writer
       - r io.Reader
       - b []byte
-
 
 linters:
   enable:

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -8,7 +8,6 @@ linters-settings:
   govet:
     enable:
       - shadow
-      - unusedwrite
   misspell:
     locale: US
   exhaustive:

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -99,6 +99,7 @@ linters:
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages
     - gochecknoinits   # Checks that no init functions are present in Go code
     - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - interfacebloat   # A linter that checks length of interface.
     - ireturn          # Accept Interfaces, Return Concrete Types
     - mnd              # An analyzer to detect magic numbers
     - nolintlint       # Reports ill-formed or insufficient nolint directives

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -89,7 +89,7 @@ linters:
     - funlen           # Tool for detection of long functions
     - gocyclo          # Computes and checks the cyclomatic complexity of functions
     - godot            # Check if comments end in a period
-    - gomnd            # An analyzer to detect magic numbers.
+    - mnd              # An analyzer to detect magic numbers
     - ireturn          # Accept Interfaces, Return Concrete Types
     - lll              # Reports long lines
     - maintidx         # maintidx measures the maintainability index of each function.

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -57,7 +57,6 @@ linters:
     - goheader         # Checks is file header matches to pattern
     - goimports        # Goimports does everything that gofmt does. Additionally it checks unused imports
     - gomoddirectives  # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
-    - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - goprintffuncname # Checks that printf-like functions are named with `f` at the end
     - gosec            # Inspects source code for security problems
     - gosimple         # Linter for Go source code that specializes in simplifying a code
@@ -82,8 +81,6 @@ linters:
     - unused           # Checks Go code for unused constants, variables, functions and types
     - wastedassign     # wastedassign finds wasted assignment statements
     - whitespace       # Tool for detection of leading and trailing whitespace
-  disable:
-    - depguard         # Go linter that checks if package imports are in a list of acceptable packages
     - containedctx     # containedctx is a linter that detects struct contained context.Context field
     - cyclop           # checks function and package cyclomatic complexity
     - funlen           # Tool for detection of long functions
@@ -99,15 +96,18 @@ linters:
     - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
     - nolintlint       # Reports ill-formed or insufficient nolint directives
     - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
+    - testpackage      # linter that makes you use a separate _test package
+    - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - varnamelen       # checks that the length of a variable's name matches its scope
+    - wsl              # Whitespace Linter - Forces you to use empty lines!
+  disable:
+    - depguard         # Go linter that checks if package imports are in a list of acceptable packages
+    - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - prealloc         # Finds slice declarations that could potentially be preallocated
     - promlinter       # Check Prometheus metrics naming via promlint
     - rowserrcheck     # checks whether Err of rows is checked successfully
     - sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
-    - testpackage      # linter that makes you use a separate _test package
-    - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - varnamelen       # checks that the length of a variable's name matches its scope
     - wrapcheck        # Checks that errors returned from external packages are wrapped
-    - wsl              # Whitespace Linter - Forces you to use empty lines!
 
 issues:
   exclude-use-default: false

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -31,11 +31,14 @@ linters:
     - asciicheck       # Simple linter to check that your code does not contain non-ASCII identifiers
     - bidichk          # Checks for dangerous unicode character sequences
     - bodyclose        # checks whether HTTP response body is closed successfully
+    - containedctx     # containedctx is a linter that detects struct contained context.Context field
     - contextcheck     # check the function whether use a non-inherited context
+    - cyclop           # checks function and package cyclomatic complexity
     - decorder         # check declaration order and count of types, constants, variables and functions
     - dogsled          # Checks assignments with too many blank identifiers (e.g. x, _, _, _, := f())
     - dupl             # Tool for code clone detection
     - durationcheck    # check for two durations multiplied together
+    - err113           # Golang linter to check the errors handling expressions
     - errcheck         # Errcheck is a program for checking for unchecked errors in go programs. These unchecked errors can be critical bugs in some cases
     - errchkjson       # Checks types passed to the json encoding functions. Reports unsupported types and optionally reports occations, where the check for the returned error can be omitted.
     - errname          # Checks that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
@@ -44,14 +47,16 @@ linters:
     - exportloopref    # checks for pointers to enclosing loop variables
     - forbidigo        # Forbids identifiers
     - forcetypeassert  # finds forced type assertions
+    - funlen           # Tool for detection of long functions
     - gci              # Gci control golang package import order and make it always deterministic.
     - gochecknoglobals # Checks that no globals are present in Go code
     - gochecknoinits   # Checks that no init functions are present in Go code
     - gocognit         # Computes and checks the cognitive complexity of functions
     - goconst          # Finds repeated strings that could be replaced by a constant
     - gocritic         # The most opinionated Go source code linter
+    - gocyclo          # Computes and checks the cyclomatic complexity of functions
+    - godot            # Check if comments end in a period
     - godox            # Tool for detection of FIXME, TODO and other comment keywords
-    - err113           # Golang linter to check the errors handling expressions
     - gofmt            # Gofmt checks whether code was gofmt-ed. By default this tool runs with -s option to check for code simplification
     - gofumpt          # Gofumpt checks whether code was gofumpt-ed.
     - goheader         # Checks is file header matches to pattern
@@ -64,41 +69,36 @@ linters:
     - grouper          # An analyzer to analyze expression groups.
     - importas         # Enforces consistent import aliases
     - ineffassign      # Detects when assignments to existing variables are not used
+    - ireturn          # Accept Interfaces, Return Concrete Types
+    - lll              # Reports long lines
+    - maintidx         # maintidx measures the maintainability index of each function.
+    - makezero         # Finds slice declarations with non-zero initial length
     - misspell         # Finds commonly misspelled English words in comments
+    - mnd              # An analyzer to detect magic numbers
+    - nakedret         # Finds naked returns in functions greater than a specified function length
+    - nestif           # Reports deeply nested if statements
     - nilerr           # Finds the code that returns nil even if it checks that the error is not nil.
     - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
+    - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
     - noctx            # noctx finds sending http request without context.Context
+    - nolintlint       # Reports ill-formed or insufficient nolint directives
+    - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
     - predeclared      # find code that shadows one of Go's predeclared identifiers
     - revive           # golint replacement, finds style mistakes
     - staticcheck      # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
     - stylecheck       # Stylecheck is a replacement for golint
     - tagliatelle      # Checks the struct tags.
     - tenv             # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
+    - testpackage      # linter that makes you use a separate _test package
+    - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
     - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert        # Remove unnecessary type conversions
     - unparam          # Reports unused function parameters
     - unused           # Checks Go code for unused constants, variables, functions and types
+    - varnamelen       # checks that the length of a variable's name matches its scope
     - wastedassign     # wastedassign finds wasted assignment statements
     - whitespace       # Tool for detection of leading and trailing whitespace
-    - containedctx     # containedctx is a linter that detects struct contained context.Context field
-    - cyclop           # checks function and package cyclomatic complexity
-    - funlen           # Tool for detection of long functions
-    - gocyclo          # Computes and checks the cyclomatic complexity of functions
-    - godot            # Check if comments end in a period
-    - mnd              # An analyzer to detect magic numbers
-    - ireturn          # Accept Interfaces, Return Concrete Types
-    - lll              # Reports long lines
-    - maintidx         # maintidx measures the maintainability index of each function.
-    - makezero         # Finds slice declarations with non-zero initial length
-    - nakedret         # Finds naked returns in functions greater than a specified function length
-    - nestif           # Reports deeply nested if statements
-    - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
-    - nolintlint       # Reports ill-formed or insufficient nolint directives
-    - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
-    - testpackage      # linter that makes you use a separate _test package
-    - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - varnamelen       # checks that the length of a variable's name matches its scope
     - wsl              # Whitespace Linter - Forces you to use empty lines!
   disable:
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -78,7 +78,6 @@ linters:
     - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
     - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
     - noctx            # noctx finds sending http request without context.Context
-    - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
     - predeclared      # find code that shadows one of Go's predeclared identifiers
     - revive           # golint replacement, finds style mistakes
     - staticcheck      # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
@@ -102,6 +101,7 @@ linters:
     - ireturn          # Accept Interfaces, Return Concrete Types
     - mnd              # An analyzer to detect magic numbers
     - nolintlint       # Reports ill-formed or insufficient nolint directives
+    - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
     - prealloc         # Finds slice declarations that could potentially be preallocated
     - promlinter       # Check Prometheus metrics naming via promlint
     - rowserrcheck     # checks whether Err of rows is checked successfully

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -91,7 +91,6 @@ linters:
     - tenv             # tenv is analyzer that detects using os.Setenv instead of t.Setenv since Go1.17
     - testpackage      # linter that makes you use a separate _test package
     - thelper          # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
-    - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - typecheck        # Like the front-end of a Go compiler, parses and type-checks Go code
     - unconvert        # Remove unnecessary type conversions
     - unparam          # Reports unused function parameters
@@ -107,6 +106,7 @@ linters:
     - promlinter       # Check Prometheus metrics naming via promlint
     - rowserrcheck     # checks whether Err of rows is checked successfully
     - sqlclosecheck    # Checks that sql.Rows and sql.Stmt are closed.
+    - tparallel        # tparallel detects inappropriate usage of t.Parallel() method in your Go test codes
     - wrapcheck        # Checks that errors returned from external packages are wrapped
 
 issues:

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -82,7 +82,6 @@ linters:
     - nilnil           # Checks that there is no simultaneous return of `nil` error and an invalid value.
     - nlreturn         # nlreturn checks for a new line before return and branch statements to increase code clarity
     - noctx            # noctx finds sending http request without context.Context
-    - nolintlint       # Reports ill-formed or insufficient nolint directives
     - paralleltest     # paralleltest detects missing usage of t.Parallel() method in your Go test
     - predeclared      # find code that shadows one of Go's predeclared identifiers
     - revive           # golint replacement, finds style mistakes
@@ -103,6 +102,7 @@ linters:
   disable:
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages
     - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    - nolintlint       # Reports ill-formed or insufficient nolint directives
     - prealloc         # Finds slice declarations that could potentially be preallocated
     - promlinter       # Check Prometheus metrics naming via promlint
     - rowserrcheck     # checks whether Err of rows is checked successfully

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -8,6 +8,7 @@ linters-settings:
   govet:
     enable:
       - shadow
+      - unusedwrite
   misspell:
     locale: US
   exhaustive:

--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -59,7 +59,6 @@ linters:
     - exportloopref    # checks for pointers to enclosing loop variables
     - forbidigo        # Forbids identifiers
     - forcetypeassert  # finds forced type assertions
-    - funlen           # Tool for detection of long functions
     - gci              # Gci control golang package import order and make it always deterministic.
     - gochecknoglobals # Checks that no globals are present in Go code
     - gocognit         # Computes and checks the cognitive complexity of functions
@@ -106,6 +105,7 @@ linters:
     - whitespace       # Tool for detection of leading and trailing whitespace
   disable:
     - depguard         # Go linter that checks if package imports are in a list of acceptable packages
+    - funlen           # Tool for detection of long functions
     - gochecknoinits   # Checks that no init functions are present in Go code
     - gomodguard       # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
     - interfacebloat   # A linter that checks length of interface.


### PR DESCRIPTION
This enables all linters relevant to Pion, updates the golangci-lint version, and removes deprecated linters.

Updated repos:

- [x] pion/webrtc https://github.com/pion/webrtc/pull/2985
- [x] pion/turn https://github.com/pion/turn/pull/432
- [x] pion/transport  https://github.com/pion/transport/pull/324
- [x] <del>pion/template</del> nothing to lint
- [x] pion/stun https://github.com/pion/stun/pull/214
- [x] pion/srtp https://github.com/pion/srtp/pull/305
- [x] pion/sdp https://github.com/pion/sdp/pull/194 https://github.com/pion/sdp/issues/193
- [x] pion/sctp https://github.com/pion/sctp/pull/362
- [x] pion/rtp https://github.com/pion/rtp/pull/289 https://github.com/pion/rtp/issues/288
- [x] pion/randutil https://github.com/pion/randutil/pull/42
- [x] pion/explainer https://github.com/pion/explainer/pull/74
- [x] pion/opus https://github.com/pion/opus/pull/65 https://github.com/pion/opus/issues/64
- [x] pion/mdns https://github.com/pion/mdns/pull/215
- [x] pion/logging https://github.com/pion/logging/pull/116
- [x] pion/ice https://github.com/pion/ice/pull/755
- [x] pion/dtls https://github.com/pion/dtls/pull/690
- [x] pion/datachannel https://github.com/pion/datachannel/pull/235
- [ ] pion/bwe-test
- [ ] pion/rtcp 
- [ ] pion/interceptor 
