### PR TITLE
Forbid the use of testing.T helpers

### DIFF
--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -19,12 +19,16 @@ linters-settings:
             recommendations:
               - errors
   forbidigo:
+    analyze-types: true
     forbid:
       - ^fmt.Print(f|ln)?$
       - ^log.(Panic|Fatal|Print)(f|ln)?$
       - ^os.Exit$
       - ^panic$
       - ^print(ln)?$
+      - p: ^testing.T.(Error|Errorf|Fatal|Fatalf|Fail|FailNow)$
+        pkg: ^testing$
+        msg: "use testify/assert instead"
   varnamelen:
     max-distance: 12
     min-name-length: 2
@@ -127,9 +131,12 @@ issues:
   exclude-dirs-use-default: false
   exclude-rules:
     # Allow complex tests and examples, better to be self contained
-    - path: (examples|main\.go|_test\.go)
+    - path: (examples|main\.go)
       linters:
+        - gocognit
         - forbidigo
+    - path: _test\.go
+      linters:
         - gocognit
 
     # Allow forbidden identifiers in CLI commands


### PR DESCRIPTION
Forbid the use of direct testing.T helpers in favor of testing toolkit like testify, To standardize this across all repos.

Updated repos:

- [x] pion/webrtc https://github.com/pion/webrtc/pull/3073
- [x] pion/rtp https://github.com/pion/rtp/pull/298
- [x] pion/turn https://github.com/pion/turn/pull/447
- [x] pion/transport  https://github.com/pion/transport/pull/333
- [x] pion/stun https://github.com/pion/stun/pull/220
- [x] pion/srtp https://github.com/pion/srtp/pull/309
- [x] pion/sdp https://github.com/pion/sdp/pull/200 https://github.com/pion/sdp/pull/201
- [x] pion/sctp https://github.com/pion/sctp/pull/366 https://github.com/pion/sctp/pull/367
- [x] pion/randutil https://github.com/pion/randutil/pull/44
- [x] pion/explainer https://github.com/pion/explainer/pull/81
- [x] pion/opus https://github.com/pion/opus/pull/69
- [x] pion/mdns https://github.com/pion/mdns/pull/222
- [x] pion/logging https://github.com/pion/logging/pull/120
- [x] pion/ice https://github.com/pion/ice/pull/776
- [x] pion/dtls https://github.com/pion/dtls/pull/699
- [x] pion/datachannel https://github.com/pion/datachannel/pull/240
- [x] pion/rtcp https://github.com/pion/rtcp/pull/192
- [x] pion/interceptor https://github.com/pion/interceptor/pull/323
