### PR TITLE
Temporarily revert Renovate change golangci-lint@7

### DIFF
--- a/.github/workflows/lint.reusable.yml
+++ b/.github/workflows/lint.reusable.yml
@@ -67,7 +67,7 @@ jobs:
           if [ -n "${PRE_LINT_HOOK}" ]; then ${PRE_LINT_HOOK}; fi
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.63.4
           args: $GOLANGCI_LINT_EXRA_ARGS


### PR DESCRIPTION
#### Description

This is a temporary revert to the previous version of golangci-lint v6 as the new version require we upgrade to golangci-lint v2 which requires some changes https://github.com/pion/.goassets/pull/226