### PR TITLE
Bump Go version to 1.21 in go.mod

### DIFF
--- a/scripts/lint-go-mod-version.sh
+++ b/scripts/lint-go-mod-version.sh
@@ -14,7 +14,7 @@ if [ -f ${SCRIPT_PATH}/../../.ci.conf ]; then
 fi
 
 if [ -z "${GO_MOD_VERSION_EXPECTED}" ]; then
-  GO_MOD_VERSION_EXPECTED="1.20" # auto-update/prev-go-version
+  GO_MOD_VERSION_EXPECTED="1.21" # auto-update/prev-go-version
 fi
 
 GO_MOD_FILE=go.mod


### PR DESCRIPTION
The `builtin.min` and `builtin.max` functions are available for use.