### PR TITLE
[goassets] Remove bwe-test repo from assets-sync

### DIFF
--- a/.github/workflows/assets-sync.yml
+++ b/.github/workflows/assets-sync.yml
@@ -16,7 +16,6 @@ jobs:
         uses: at-wat/assets-sync-action@v0
         with:
           repos: |
-            pion/bwe-test
             pion/datachannel
             pion/dtls
             pion/example-webrtc-applications


### PR DESCRIPTION
#### Description
- Removed `pion/bwe-test` from the repository list in `.github/workflows/assets-sync.yml`. The `bwe-test` repository has a dependency on the `libvpx-dev` library which is not available in the standard CI environment used by the assets-sync workflow. This causes the test process of the `bwe-test` repository to fail. I will write standalone CI yaml file in `bwe-test` repository.

