### PR TITLE
Update golangci-lint to 2.7.2

### DIFF
--- a/.github/workflows/lint.reusable.yml
+++ b/.github/workflows/lint.reusable.yml
@@ -69,5 +69,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.4.0
+          version: v2.7.2
           args: $GOLANGCI_LINT_EXRA_ARGS


### PR DESCRIPTION
Updating golangci-lint to 2.7.2

This is a follow up to https://github.com/pion/turn/pull/499

Planning to update the downstream repos with the lint fixes.

