### PR TITLE
Remove deleted script usage from install-hooks

### DIFF
--- a/ci/.github/install-hooks.sh
+++ b/ci/.github/install-hooks.sh
@@ -17,4 +17,3 @@ SCRIPT_PATH="$(realpath "$(dirname "$0")")"
 
 cp "${GOASSETS_PATH}/hooks/commit-msg.sh" "${SCRIPT_PATH}/../.git/hooks/commit-msg"
 cp "${GOASSETS_PATH}/hooks/pre-commit.sh" "${SCRIPT_PATH}/../.git/hooks/pre-commit"
-cp "${GOASSETS_PATH}/hooks/pre-push.sh" "${SCRIPT_PATH}/../.git/hooks/pre-push"


### PR DESCRIPTION
The `pre-push` script does not exist anymore, it was deleted in this commit:

https://github.com/pion/.goassets/commit/d5f62f5ad3cf4f44b775252a598a2d6bacaaf3fe

I noticed it when tried to run `install-hooks` in my local turn repo:
```
ali@Alis-MacBook-Pro-4 ~/s/turn (master)> .github/install-hooks.sh
Already on 'master'
Your branch is up to date with 'origin/master'.
HEAD is now at 60c5714 Update actions/upload-artifact action to v6
cp: /Users/ali/src/turn/.github/.goassets/hooks/pre-push.sh: No such file or directory
```