### PR TITLE
Add package-comments lint rule

### DIFF
--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -111,6 +111,10 @@ linters:
         - name: use-any
           severity: warning
           disabled: false
+        # Keep package documentation consistent and avoid duplicate package comments.
+        - name: package-comments
+          severity: warning
+          disabled: false
     misspell:
       locale: US
     varnamelen:


### PR DESCRIPTION
#### Description
Add the `revive/package-comments` rule to keep package documentation consistent and avoid duplicate package comments.

#### Reference issue
Fixes #...
