### PR TITLE
Skip Go upgrade if no go.mod

### DIFF
--- a/.github/tools/update_go_mod_version.sh
+++ b/.github/tools/update_go_mod_version.sh
@@ -6,6 +6,11 @@
 
 set -e
 
+# some asset-sync targets do not have a go.mod file.
+if [[ ! -f go.mod ]]; then
+  exit 0
+fi
+
 . "${ASSETS_DIR}/scripts/go-mod-version.sh"
 
 # Normalize expected version to semver so both 1.24 and 1.24.0 become 1.24.0.


### PR DESCRIPTION
#### Description
Sync fails to run because explainer doesn't have a go.mod file, we should remove explainer since it got migrated to https://github.com/webrtc-for-the-curious/ but we still need to fix this, part of #275 