### PR TITLE
Set LLL line-length to 320

### DIFF
--- a/ci/.golangci.yml
+++ b/ci/.golangci.yml
@@ -78,6 +78,8 @@ linters:
     - wrapcheck        # Checks that errors returned from external packages are wrapped
     - wsl              # Whitespace Linter - Forces you to use empty lines!
   settings:
+    lll:
+      line-length: 320
     staticcheck:
       checks:
         - all


### PR DESCRIPTION
#### Description
As applied in https://github.com/pion/dtls/pull/1092 setting LLL to 320 from 240 saves so much LoC, especially in tests.